### PR TITLE
This retrieves the preview ref manually and adds it to the Prismic API request

### DIFF
--- a/src/lib/prismic.ts
+++ b/src/lib/prismic.ts
@@ -1,6 +1,14 @@
 import { getRepositoryEndpoint, createClient } from '@prismicio/client'
 
-const endpoint = getRepositoryEndpoint('monogram')
-const prismicClient = () => createClient(endpoint)
+export const repositoryName = 'sam-onboarding-blog-5'
+const endpoint = getRepositoryEndpoint(repositoryName)
+
+const prismicClient = (prismicCookie) => {
+	// Access preview ref from preview cookie
+	const ref = prismicCookie?.[`${repositoryName}.prismic.io`]?.preview
+
+	// Pass preview ref to preview cookie
+	return createClient(endpoint, { ref })
+}
 
 export default prismicClient

--- a/src/routes/[uid].ts
+++ b/src/routes/[uid].ts
@@ -1,9 +1,23 @@
 import prismicClient from '../lib/prismic'
 import type { RequestHandler } from '@sveltejs/kit'
 
-export const get: RequestHandler = async ({ params }) => {
-	const post = (await prismicClient()
-		.getByUID('blog', params.uid)
+export const get: RequestHandler = async ({ params, request }) => {
+	// Retrieve prismic preview cookie from request object
+	const prismicCookie = JSON.parse(
+		request.headers
+			.get('cookie')
+			?.split(';')
+			.map(function (c) {
+				return c.trim().split('=').map(decodeURIComponent)
+			})
+			.find((e) => e[0] === 'io.prismic.preview')
+			?.slice(1)
+			.join('=') || '{}'
+	)
+
+	// Pass cookie to createClient()
+	const post = (await prismicClient(prismicCookie)
+		.getByUID('post', params.uid)
 		// eslint-disable-next-line
 		.catch((err) => console.log(err))) as Record<string, any>
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,8 +1,12 @@
+<script>
+	import { repositoryName } from '$lib/prismic'
+</script>
+
 <svelte:head>
 	<script
 		async
 		defer
-		src="https://static.cdn.prismic.io/prismic.js?new=true&repo=monogram"></script>
+		src={`https://static.cdn.prismic.io/prismic.js?new=true&repo=${repositoryName}`}></script>
 </svelte:head>
 
 <slot />


### PR DESCRIPTION
In `[uid].ts`, retrieve the preview cookie manually from the request object, and pass it as a parameter to `prismicClient()`. In `prismic.ts`, retrieve the Prismic preview ref manually from the cookie, and pass it as the `ref` parameter to the `createClient()` options.